### PR TITLE
Fix xgboost version conflict

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -53,7 +53,7 @@ RUN $PIPINST \
     tensorflow-probability==0.18.0 \
     tflite \
     torchvision==0.13.1 \
-    xgboost
+    xgboost>=1.1.0,<1.6.0
 
 RUN $PIPINST git+https://github.com/onnx/onnx-tensorflow.git@v1.10.0
 RUN $PIPINST git+https://github.com/onnx/tensorflow-onnx.git@v1.13.0

--- a/environments/development-environment-gpu.def
+++ b/environments/development-environment-gpu.def
@@ -67,7 +67,7 @@ From: nvidia/cuda:11.4.2-cudnn8-devel-ubuntu20.04
         torchvision==0.13.1 \
         tornado \
         tqdm \
-        xgboost
+        xgboost>=1.1.0,<1.6.0
 
     $PIPINST git+https://github.com/onnx/onnx-tensorflow.git@v1.10.0
     $PIPINST git+https://github.com/onnx/tensorflow-onnx.git@v1.13.0

--- a/environments/development-environment.def
+++ b/environments/development-environment.def
@@ -58,7 +58,7 @@ From: archlinux:latest
         tensorflow-probability==0.18.0 \
         tflite \
         torchvision==0.13.1 \
-        xgboost
+        xgboost>=1.1.0,<1.6.0
 
     $PIPINST git+https://github.com/onnx/onnx-tensorflow.git@v1.10.0
     $PIPINST git+https://github.com/onnx/tensorflow-onnx.git@v1.13.0


### PR DESCRIPTION
There is version conflict described in https://github.com/apache/tvm/issues/12009
Versions restriction as in https://github.com/apache/tvm/blob/main/python/gen_requirements.py#L279,
added to Apache TVM should eliminate this conflict.